### PR TITLE
fix arguments not passed properly

### DIFF
--- a/Invoke-Runas.ps1
+++ b/Invoke-Runas.ps1
@@ -140,7 +140,7 @@ function Invoke-Runas {
 	echo "`n[>] Calling Advapi32::CreateProcessWithLogonW"
 	$CallResult = [Advapi32]::CreateProcessWithLogonW(
 		$User, $Domain, $Password, $LogonType, $Binary,
-		$Args, 0x04000000, $null, $GetCurrentPath,
+		" " + $Args, 0x04000000, $null, $GetCurrentPath,
 		[ref]$StartupInfo, [ref]$ProcessInfo)
 	
 	if (!$CallResult) {


### PR DESCRIPTION
It appears that $Args will only work when passed with at least one leading white space.
Only tested on Win10 x64 1903 with mmc.exe binary.